### PR TITLE
Handle mpc80 generation where zero padding of 9.999 was writing 010.00

### DIFF
--- a/src/cluster2mpc80a.cpp
+++ b/src/cluster2mpc80a.cpp
@@ -429,8 +429,8 @@ int main(int argc, char *argv[])
 		outstream1 << year << " ";
 		if(month<10) outstream1 << "0";
 		outstream1 << month << " ";
-		if(day<10.0l) outstream1  << fixed << setprecision(6) << "0";
-		outstream1  << fixed << setprecision(6) << day;
+		// Use setfill and setw for zero-padding.
+		outstream1 << setfill('0') << setw(9) << fixed << setprecision(6) << day;
 		// Convert RA, Dec from decimal degrees to sexagesimal format.
 		rahr = int(detvec[i1].RA/15.0l);
 		ramin = int(detvec[i1].RA*4.0l - double(rahr)*60.0l);
@@ -451,14 +451,12 @@ int main(int argc, char *argv[])
 	      outstream1 << rahr << " ";
 	      if(ramin<10) outstream1 << "0";
 	      outstream1 << ramin << " ";
-	      if(rasec<10.0l) outstream1 << "0";
-	      outstream1 << fixed << setprecision(3) << rasec << signstring;
+	      outstream1 << setfill('0') << setw(6) << fixed << setprecision(3) << rasec << signstring;
 	      if(decdeg<10) outstream1 << "0";
 	      outstream1 << decdeg << " ";
 	      if(decmin<10) outstream1 << "0";
 	      outstream1 << decmin << " ";
-	      if(decsec<10.0l) outstream1 << "0";
-	      outstream1 << fixed << setprecision(2) << decsec << "         ";
+	      outstream1 << setfill('0') << setw(5) << fixed << setprecision(2) << decsec << "         ";
 	      // Write out magnitude and band.
 	      outstream1 << fixed << setprecision(1) << detvec[i1].mag << " " << detvec[i1].band;
 	      // Add correct number of spaces after band.

--- a/src/cluster2mpc80b.cpp
+++ b/src/cluster2mpc80b.cpp
@@ -197,8 +197,8 @@ int main(int argc, char *argv[])
       outstream1 << year << " ";
       if(month<10) outstream1 << "0";
       outstream1 << month << " ";
-      if(day<10.0l) outstream1  << fixed << setprecision(6) << "0";
-      outstream1  << fixed << setprecision(6) << day;
+		  // Use setfill and setw for zero-padding.
+		  outstream1 << setfill('0') << setw(9) << fixed << setprecision(6) << day;
       // Convert RA, Dec from decimal degrees to sexagesimal format.
       rahr = int(RA/15.0l);
       ramin = int(RA*4.0l - double(rahr)*60.0l);
@@ -218,14 +218,12 @@ int main(int argc, char *argv[])
       outstream1 << rahr << " ";
       if(ramin<10) outstream1 << "0";
       outstream1 << ramin << " ";
-      if(rasec<10.0l) outstream1 << "0";
-      outstream1 << fixed << setprecision(3) << rasec << signstring;
+      outstream1 << setfill('0') << setw(6) << fixed << setprecision(3) << rasec << signstring;
       if(decdeg<10) outstream1 << "0";
       outstream1 << decdeg << " ";
       if(decmin<10) outstream1 << "0";
       outstream1 << decmin << " ";
-      if(decsec<10.0l) outstream1 << "0";
-      outstream1 << fixed << setprecision(2) << decsec << "         ";
+	    outstream1 << setfill('0') << setw(5) << fixed << setprecision(2) << decsec << "         ";
       // Write out magnitude and band.
       outstream1 << fixed << setprecision(1) << mag << " " << band;
       // Add correct number of spaces after band.


### PR DESCRIPTION
I found a unique situation where if day was 9.9999996 or higher, rasec was 9.9996 or higher or decsec was 9.996 or higher, the current would would write out something like 010.00 or 010.000 because the if statement was padding it and then the fixed setprecision was rounding up to 10. Using setfill and setw with setprecision fixes this problem. I hope this helps!